### PR TITLE
refactor: .overlay, add: node identifier know-how

### DIFF
--- a/boards/esp32s2_saola.overlay
+++ b/boards/esp32s2_saola.overlay
@@ -1,12 +1,11 @@
 / {
     aliases {
-        led0 = &led0;
+        board-led = &led0;
     };
     leds {
         compatible = "gpio-leds";
         led0: led_0 {
-            gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-            label = "LED 0";
+            gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>; 
         };
     };
 };

--- a/src/main.c
+++ b/src/main.c
@@ -10,8 +10,13 @@
 /* 1000 msec = 1 sec */
 #define SLEEP_TIME_MS   1000
 
-/* The devicetree node identifier for the "led0" alias. */
-#define LED0_NODE DT_ALIAS(led0)
+/* (Required) Create a node identifier for the project's on-board led */
+  /* MagTag - red led "D13" - pin 13 - assigned in esp32s2_saola.overlay */
+  /* -- The .overlay file is used for device specific info so main.c stays generic -- */
+/* 3 options to create a node identifier*/
+#define LED0_NODE DT_ALIAS(board_led) // from .overlay to .c file, the (-) changes to (_)
+// #define LED0_NODE DT_NODELABEL(led0)
+// #define LED0_NODE DT_PATH(leds, led_0)
 
 /*
  * A build error on this line means your board is unsupported.


### PR DESCRIPTION
*Pain Point*
- Previous .overlay file re-used names (led0) making it unclear which sections were used for the creation of the node identifier in the application code. 

*Updates*
- I created unique names in .overlay and removed the un-needed label property for clarity. 

- I noted 3 ways to make a node identifier so its easier to understand how the .overlay file is operating
